### PR TITLE
fix `fileExists` ambiguity for Nim < 1.4 & bump version

### DIFF
--- a/nimcuda.nimble
+++ b/nimcuda.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.8"
+version       = "0.1.9"
 author        = "Andrea Ferretti"
 description   = "Nim binding for CUDA"
 license       = "Apache2"
@@ -11,6 +11,12 @@ skipDirs      = @["headers", "include", "c2nim", "examples", "htmldocs"]
 requires "nim >= 0.16.0"
 
 import os, strutils
+
+proc fExists(f: string): bool =
+  when (NimMajor, NimMinor) < (1, 4):
+    result = os.fileExists(f)
+  else:
+    result = fileExists(f)
 
 proc patch(libName: string): string =
   when defined(windows):
@@ -23,7 +29,7 @@ proc patch(libName: string): string =
     patchPath = "c2nim" / libName
     outPath = "headers" / libName
     libContent =
-      if fileExists(simpleLibPath): readFile(simpleLibPath)
+      if fExists(simpleLibPath): readFile(simpleLibPath)
       else: readFile(libPath) #.replace("#if defined(__cplusplus)", "#ifdef __cplusplus")
     patchContent = readFile(patchPath)
   writeFile(outPath, patchContent & libContent)


### PR DESCRIPTION
Trying to fix #12. 

This is a bit confusing to me. According to the docs `fileExists` lives in `os` even on devel. But if I prefix the `fileExists` call with `os` independent of Nim version, `nimble` complains about it not existing. Hence the extra proc to differentiate. I hope on older Nim versions this actually works correctly.