### PR TITLE
Fix #27 + Cuda install detection

### DIFF
--- a/nimcuda.nimble
+++ b/nimcuda.nimble
@@ -251,13 +251,6 @@ proc exampleConfig(version: CudaVersion) =
   --stacktrace: on
   --linetrace: on
   --debuginfo
-  when hostos == "windows":
-    switch("cincludes", systemCudaInclude(version))
-    switch("clibdir", systemCudaCLib(version))
-  else:
-    switch("cincludes", systemCudaInclude(version))
-    switch("cincludes", "/usr/include/x86_64-linux-gnu/")
-    switch("clibdir", systemCudaCLib(version))
   switch("path", thisDir() / nimcudaSourceDir(version))
   --run
 

--- a/src/nimcuda/cuda12_5/cuComplex.nim
+++ b/src/nimcuda/cuda12_5/cuComplex.nim
@@ -57,6 +57,8 @@ template `div`(a: cfloat, b: cfloat): cfloat = a / b
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
 ##
+import ./libpaths
+tellCompilerToUseCuda()
 
 when not defined(CUDACC_RTC):
   when defined(GNUC):

--- a/src/nimcuda/cuda12_5/cublas_api.nim
+++ b/src/nimcuda/cuda12_5/cublas_api.nim
@@ -10,6 +10,9 @@ else:
 import
   library_types
 
+import ./libpaths
+tellCompilerToUseCuda()
+
 ##
 ##  Copyright 1993-2022 NVIDIA Corporation. All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/cublas_v2.nim
+++ b/src/nimcuda/cuda12_5/cublas_v2.nim
@@ -51,6 +51,9 @@
 ##  Cublas name functions to the actual _v2 implementations.
 ##
 
+import ./libpaths
+tellCompilerToUseCuda()
+
 when defined(CUBLAS_H):
   discard
 import

--- a/src/nimcuda/cuda12_5/cuda.nim
+++ b/src/nimcuda/cuda12_5/cuda.nim
@@ -8,7 +8,7 @@ else:
   const
     libName = "libcuda.so"
 
-import ./[helpers, libpaths]
+import ./helpers, ./libpaths
 tellCompilerToUseCuda()
 
 {.push importc, dynlib: libName, header: "cuda.h".}

--- a/src/nimcuda/cuda12_5/cuda.nim
+++ b/src/nimcuda/cuda12_5/cuda.nim
@@ -11,6 +11,8 @@ else:
 import ./[helpers, libpaths]
 tellCompilerToUseCuda()
 
+{.push importc, dynlib: libName, header: "cuda.h".}
+
 ##
 ##  Copyright 1993-2023 NVIDIA Corporation.  All rights reserved.
 ##
@@ -26394,3 +26396,5 @@ elif defined(CUDA_API_PER_THREAD_DEFAULT_STREAM):
 when defined(GNUC):
   when defined(CUDA_API_PUSH_VISIBILITY_DEFAULT):
     discard
+
+{.pop.}

--- a/src/nimcuda/cuda12_5/cuda.nim
+++ b/src/nimcuda/cuda12_5/cuda.nim
@@ -8,7 +8,8 @@ else:
   const
     libName = "libcuda.so"
 
-import ./helpers
+import ./[helpers, libpaths]
+tellCompilerToUseCuda()
 
 ##
 ##  Copyright 1993-2023 NVIDIA Corporation.  All rights reserved.

--- a/src/nimcuda/cuda12_5/cuda_occupancy.nim
+++ b/src/nimcuda/cuda12_5/cuda_occupancy.nim
@@ -1,4 +1,6 @@
 import ./helpers
+import ./libpaths
+tellCompilerToUseCuda()
 
 ##
 ##  Copyright 1993-2017 NVIDIA Corporation.  All rights reserved.

--- a/src/nimcuda/cuda12_5/cuda_runtime_api.nim
+++ b/src/nimcuda/cuda12_5/cuda_runtime_api.nim
@@ -10,6 +10,9 @@ else:
 import
   vector_types, driver_types, surface_types, texture_types
 
+import ./libpaths
+tellCompilerToUseCuda()
+
 ##
 ##  Copyright 1993-2018 NVIDIA Corporation.  All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/cufft.nim
+++ b/src/nimcuda/cuda12_5/cufft.nim
@@ -10,6 +10,9 @@ else:
 import
   cuComplex, library_types, driver_types
 
+import ./libpaths
+tellCompilerToUseCuda()
+
 ##  Copyright 2005-2021 NVIDIA Corporation.  All rights reserved.
 ##
 ##  NOTICE TO LICENSEE:

--- a/src/nimcuda/cuda12_5/curand.nim
+++ b/src/nimcuda/cuda12_5/curand.nim
@@ -17,6 +17,9 @@ type
   curandDiscreteDistribution_st {.bycopy.} = object
 
 
+import ./libpaths
+tellCompilerToUseCuda()
+
 import
   library_types, driver_types
 

--- a/src/nimcuda/cuda12_5/cusolverDn.nim
+++ b/src/nimcuda/cuda12_5/cusolverDn.nim
@@ -9,7 +9,8 @@ else:
     libName = "libcusolver.so"
 import
   cuComplex, cublas_api, cusolver_common, library_types, driver_types
-
+import ./libpaths
+tellCompilerToUseCuda()
 ##
 ##  Copyright 2014 NVIDIA Corporation.  All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/cusolverRf.nim
+++ b/src/nimcuda/cuda12_5/cusolverRf.nim
@@ -9,7 +9,8 @@ else:
     libName = "libcusolver.so"
 import
   cusolver_common
-
+import ./libpaths
+tellCompilerToUseCuda()
 ##
 ##  Copyright 1993-2014 NVIDIA Corporation.  All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/cusolverSp.nim
+++ b/src/nimcuda/cuda12_5/cusolverSp.nim
@@ -9,7 +9,8 @@ else:
     libName = "libcusolver.so"
 import
   cuComplex, driver_types, cusolver_common, cusparse
-
+import ./libpaths
+tellCompilerToUseCuda()
 ##
 ##  Copyright 2014 NVIDIA Corporation.  All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/cusolver_common.nim
+++ b/src/nimcuda/cuda12_5/cusolver_common.nim
@@ -11,7 +11,8 @@ else:
     libName = "libcusolver.so"
 import
   library_types
-
+import ./libpaths
+tellCompilerToUseCuda()
 ##
 ##  Copyright 2014 NVIDIA Corporation.  All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/cusparse.nim
+++ b/src/nimcuda/cuda12_5/cusparse.nim
@@ -12,7 +12,8 @@ else:
     libName = "libcusparse.so"
 import
   library_types, driver_types, cuComplex
-
+import ./libpaths
+tellCompilerToUseCuda()
 ##
 ##  Copyright 1993-2023 NVIDIA Corporation.  All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/driver_types.nim
+++ b/src/nimcuda/cuda12_5/driver_types.nim
@@ -56,6 +56,9 @@
 import
   vector_types
 
+import ./libpaths
+tellCompilerToUseCuda()
+
 when not defined(CUDACC_RTC_MINIMAL):
   ##
   ##  \defgroup CUDART_TYPES Data types used by CUDA Runtime

--- a/src/nimcuda/cuda12_5/libpaths.nim
+++ b/src/nimcuda/cuda12_5/libpaths.nim
@@ -1,4 +1,12 @@
 
+##[This module implements some auto-detection of cuda installation locations,
+   as well as communication with the c compilers about this info.
+
+   If you want to manually overide the autodetection, pass the nim compiler
+   `-d:CudaLib="PATH_TO_CUDA_DYN_LIBS"` and/or
+   `-d:CudaIncludes="PATH_TO_CUDA_HEADERS"`.
+]##
+
 #[The following is a rip of std/distros, slightly modified for compile-time
   use.
   The extra specificity compared to normal `defined` tests or `hostOS`

--- a/src/nimcuda/cuda12_5/libpaths.nim
+++ b/src/nimcuda/cuda12_5/libpaths.nim
@@ -62,20 +62,28 @@ proc detectOsImpl(d: Distribution): bool {.compileTime.} =
       else:
         result = false
     elif defined(linux):
+      const EasyLinux = when (NimMajor, NimMinor) >= (1, 6):
+          {Distribution.Elementary, Distribution.Ubuntu, Distribution.Debian,
+          Distribution.Fedora, Distribution.OpenMandriva, Distribution.CentOS,
+          Distribution.Alpine, Distribution.Mageia, Distribution.Zorin,
+          Distribution.Void}
+        else:
+          {Distribution.Elementary, Distribution.Ubuntu, Distribution.Debian,
+          Distribution.Fedora, Distribution.OpenMandriva, Distribution.CentOS,
+          Distribution.Alpine, Distribution.Mageia, Distribution.Zorin}
+
       case d
       of Distribution.Gentoo:
         result = ("-" & $d & " ") in uname()
-      of Distribution.Elementary, Distribution.Ubuntu, Distribution.Debian,
-        Distribution.Fedora, Distribution.OpenMandriva, Distribution.CentOS,
-        Distribution.Alpine, Distribution.Mageia, Distribution.Zorin,
-        Distribution.Void:
+      of EasyLinux:
         result = toLowerAscii($d) in osReleaseID()
       of Distribution.RedHat:
         result = "rhel" in osReleaseID()
       of Distribution.ArchLinux:
         result = "arch" in osReleaseID()
-      of Distribution.Artix:
-        result = "artix" in osReleaseID()
+      # when (NimMajor, NimMinor) >= (1, 6):
+      #   of Distribution.Artix:
+      #     result = "artix" in osReleaseID()
       of Distribution.NixOS:
         # Check if this is a Nix build or NixOS environment
         result = existsEnv("NIX_BUILD_TOP") or

--- a/src/nimcuda/cuda12_5/libpaths.nim
+++ b/src/nimcuda/cuda12_5/libpaths.nim
@@ -30,7 +30,6 @@ var
 template cmdRelease(cmd, cache): untyped =
   if cache.len == 0:
     # cache = (when defined(nimscript): gorge(cmd) else: execProcess(cmd))
-    echo defined(nimVm)
     cache = gorge(cmd)
   cache
 

--- a/src/nimcuda/cuda12_5/libpaths.nim
+++ b/src/nimcuda/cuda12_5/libpaths.nim
@@ -16,7 +16,9 @@
 
 
 from std/distros import Distribution
-import std/[os, envvars, strutils, macros, macrocache]
+import std/[os, strutils, macros, macrocache]
+when NimMajor == 2:
+  import std/envvars
 
 
 # we cache the result of the 'cmdRelease'

--- a/src/nimcuda/cuda12_5/libpaths.nim
+++ b/src/nimcuda/cuda12_5/libpaths.nim
@@ -1,0 +1,135 @@
+
+#[The following is a rip of std/distros, slightly modified for compile-time
+  use.
+  The extra specificity compared to normal `defined` tests or `hostOS`
+  is needed because some linux distros install cuda in very different places
+  (im looking at you, arch!)
+]#
+
+
+from std/distros import Distribution
+import std/[os, envvars, strutils]
+
+
+# we cache the result of the 'cmdRelease'
+# execution for faster platform detections.
+var
+  unameRes {.compileTime.}: string
+  osReleaseIDRes {.compileTime.}: string
+  releaseRes {.compileTime.}: string
+  hostnamectlRes {.compileTime.}: string
+
+template cmdRelease(cmd, cache): untyped =
+  if cache.len == 0:
+    # cache = (when defined(nimscript): gorge(cmd) else: execProcess(cmd))
+    echo defined(nimVm)
+    cache = gorge(cmd)
+  cache
+
+template uname(): untyped = cmdRelease("uname -a", unameRes)
+template osReleaseID(): untyped =
+  cmdRelease("cat /etc/os-release | grep ^ID=", osReleaseIDRes)
+template release(): untyped = cmdRelease("lsb_release -d", releaseRes)
+template hostnamectl(): untyped = cmdRelease("hostnamectl", hostnamectlRes)
+
+proc detectOsWithAllCmd(d: Distribution): bool {.compileTime.} =
+  let dd = toLowerAscii($d)
+  result = dd in toLowerAscii(osReleaseID()) or dd in toLowerAscii(release()) or
+            dd in toLowerAscii(uname()) or ("operating system: " & dd) in
+                toLowerAscii(hostnamectl())
+
+proc detectOsImpl(d: Distribution): bool {.compileTime.} =
+  case d
+  of Distribution.Windows: result = defined(windows)
+  of Distribution.Posix: result = defined(posix)
+  of Distribution.MacOSX: result = defined(macosx)
+  of Distribution.Linux: result = defined(linux)
+  of Distribution.BSD: result = defined(bsd)
+  else:
+    when defined(bsd):
+      case d
+      of Distribution.FreeBSD, Distribution.NetBSD, Distribution.OpenBSD:
+        result = $d in uname()
+      else:
+        result = false
+    elif defined(linux):
+      case d
+      of Distribution.Gentoo:
+        result = ("-" & $d & " ") in uname()
+      of Distribution.Elementary, Distribution.Ubuntu, Distribution.Debian,
+        Distribution.Fedora, Distribution.OpenMandriva, Distribution.CentOS,
+        Distribution.Alpine, Distribution.Mageia, Distribution.Zorin,
+        Distribution.Void:
+        result = toLowerAscii($d) in osReleaseID()
+      of Distribution.RedHat:
+        result = "rhel" in osReleaseID()
+      of Distribution.ArchLinux:
+        result = "arch" in osReleaseID()
+      of Distribution.Artix:
+        result = "artix" in osReleaseID()
+      of Distribution.NixOS:
+        # Check if this is a Nix build or NixOS environment
+        result = existsEnv("NIX_BUILD_TOP") or
+          existsEnv("__NIXOS_SET_ENVIRONMENT_DONE")
+      of Distribution.OpenSUSE:
+        result = "suse" in toLowerAscii(uname()) or
+          "suse" in toLowerAscii(release())
+      of Distribution.GoboLinux:
+        result = "-Gobo " in uname()
+      of Distribution.Solaris:
+        let uname = toLowerAscii(uname())
+        result = ("sun" in uname) or ("solaris" in uname)
+      of Distribution.Haiku:
+        result = defined(haiku)
+      else:
+        result = detectOsWithAllCmd(d)
+    else:
+      result = false
+
+template detectOs(d: untyped): bool =
+  ## Distro/OS detection. For convenience, the
+  ## required `Distribution.` qualifier is added to the
+  ## enum value.
+  detectOsImpl(Distribution.d)
+
+
+
+# begin actual detection
+when detectOs(Windows):
+  from std/os import getEnv, `/`
+  const
+    CudaPath = getEnv("CUDA_PATH")
+    CudaIncludes* {.strdefine.} = CudaPath / "include"
+    CudaLib* {.strdefine.} = CudaPath / "lib64"
+
+elif detectOs(ArchLinux):
+  from std/os import `/`
+  const
+    CudaPath = "/opt/cuda"
+    CudaIncludes* {.strdefine.} = CudaPath / "include"
+    CudaLib* {.strdefine.} = CudaPath / "lib64"
+
+elif detectOs(Linux):
+  # Generic linux catch-all.
+  # This includes anyone following the cuda installation guide.
+  const
+    CudaPath = "/usr/local/cuda"
+    CudaIncludes* {.strdefine.} = CudaPath / "include"
+    CudaLib* {.strdefine.} = CudaPath / "lib64"
+
+else:
+  # Some wild operating system!
+  const
+    CudaIncludes* {.strdefine.} = "unknown"
+    CudaLib* {.strdefine.} = "unknown"
+
+
+# check for validity
+when not dirExists(CudaIncludes):
+  {.error: "Could not find the cuda source headers! Please specify the " &
+     "location of the cuda includes directory by passing " &
+     "`-d:CudaIncludes=\"YOUR_PATH\"` to the nim compiler.".}
+elif not dirExists(CudaLib):
+  {.error: "Could not find the cuda shared libraries! Please specify the " &
+     "location of the cuda library directory by passing " &
+     "`-d:CudaLib=\"YOUR_PATH\"` to the nim compiler.".}

--- a/src/nimcuda/cuda12_5/library_types.nim
+++ b/src/nimcuda/cuda12_5/library_types.nim
@@ -46,6 +46,8 @@
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
 ##
+import ./libpaths
+tellCompilerToUseCuda()
 
 type
   cudaDataType* = enum

--- a/src/nimcuda/cuda12_5/nvblas.nim
+++ b/src/nimcuda/cuda12_5/nvblas.nim
@@ -9,7 +9,8 @@ else:
     libName = "libnvblas.so"
 import
   cuComplex
-
+import ./libpaths
+tellCompilerToUseCuda()
 ##
 ##  Copyright 1993-2019 NVIDIA Corporation. All rights reserved.
 ##

--- a/src/nimcuda/cuda12_5/nvrtc.nim
+++ b/src/nimcuda/cuda12_5/nvrtc.nim
@@ -7,6 +7,10 @@ elif defined(macosx):
 else:
   const
     libName = "libnvrtc.so"
+
+import ./libpaths
+tellCompilerToUseCuda()
+
 type nvrtcProgramObj {.noDecl, incompleteStruct.} = object
 ##
 ##  NVIDIA_COPYRIGHT_BEGIN

--- a/src/nimcuda/cuda12_5/surface_types.nim
+++ b/src/nimcuda/cuda12_5/surface_types.nim
@@ -52,7 +52,8 @@
 ##                                                                               *
 ##                                                                               *
 ## *****************************************************************************
-
+import ./libpaths
+tellCompilerToUseCuda()
 when not defined(CUDACC_RTC_MINIMAL):
   ##
   ##  \addtogroup CUDART_TYPES

--- a/src/nimcuda/cuda12_5/texture_types.nim
+++ b/src/nimcuda/cuda12_5/texture_types.nim
@@ -52,7 +52,8 @@
 ##                                                                               *
 ##                                                                               *
 ## *****************************************************************************
-
+import ./libpaths
+tellCompilerToUseCuda()
 when not defined(CUDACC_RTC_MINIMAL):
   ##
   ##  \addtogroup CUDART_TYPES

--- a/src/nimcuda/cuda12_5/vector_types.nim
+++ b/src/nimcuda/cuda12_5/vector_types.nim
@@ -46,7 +46,8 @@
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
 ##
-
+import ./libpaths
+tellCompilerToUseCuda()
 type
   char1* {.importc: "char1", header: "vector_types.h", bycopy.} = object
     x* {.importc: "x".}: cchar


### PR DESCRIPTION
This pr fixes #27, at least as far as it has been seen on the cuda driver api. Also bundled with it comes some simple cuda install detection. This is a step to solving #25.

I ran into some issues on adding the header pragma to other cuda nim files:

- C compiler not being able to parse the header
- Linker not getting passed the object file

If other issues similar to this one arise on other files, I'll put some more effort into getting those done as well.